### PR TITLE
fix: smarter nesting of headings / categories

### DIFF
--- a/src/components/ApifySearch.tsx
+++ b/src/components/ApifySearch.tsx
@@ -69,7 +69,7 @@ function Autocomplete(props: any) {
                   params: {
                     hitsPerPage: 20,
                     attributesToSnippet: ['content:35'],
-                    attributesToRetrieve: ['content', 'hierarchy', 'toc', 'url'],
+                    attributesToRetrieve: ['content', 'hierarchy', 'toc', 'url', 'breadcrumbs'],
                     filters: props.filters ?? 'version:latest'
                   },
                 },

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,18 +1,25 @@
 import { decode } from "html-entities";
+import { isHeading } from "../utils/isHeading";
 
 /**
  * Renders breadcrumbs for the current item.
  */
 export function Breadcrumbs({ item, highlight }: any) {
-    const x = Object.entries(item?._highlightResult?.hierarchy ?? {})
-      .filter(([_,b]) => b)
-      .sort(([a],[b]) => a.localeCompare(b))
-      .slice(1);
+    const breadcrumbs = [
+      ...((!isHeading(item)) ? 
+        item?.breadcrumbs.map((x: any) => [null,{ value: x, matchLevel: 'full' }] ?? []) :
+        item?.breadcrumbs.map((x: any) => [null,{ value: x, matchLevel: 'full' }] ?? []).slice(-1)
+      ),
+      ...Object.entries(item?._highlightResult?.hierarchy ?? {})
+        .filter(([_,b]) => b)
+        .sort(([a],[b]) => a.localeCompare(b))
+        .slice(1)
+    ].slice(1);
   
     return (
       <div className='overflow-x-hidden overflow-ellipsis whitespace-nowrap leading-normal h-auto'>
         { 
-          x.map(([_,b]: any, index) => ( (b?.value && b.value.length > 3) ?
+          breadcrumbs.map(([_,b]: any, index) => ( (b?.value && b.value.length > 3) ?
           (<span style={{color: 'slategray'}} className="breadcrumbs__item" key={index.toString()}>
             {highlight({hit: { value: b.value ? decode(b.value) : '' }, attribute: 'value'})}
           </span>) : null

--- a/src/components/ResultsItems.tsx
+++ b/src/components/ResultsItems.tsx
@@ -66,7 +66,7 @@ export function ResultsItems({ items, setActiveItemId, setContext, components, s
           isActive={state.context.preview.url === item.url}
           className={`p-2 hover:cursor-pointer 
             ${
-              a.slice(0, i).some((x: any) => (countFamily(x, item) === 2)) ? 'pl-10' : 'pl-3'
+              a.slice(0, i).some((x: any) => (countFamily(x, item) >= 2)) ? 'pl-10' : 'pl-3'
             }
           `}  
           onMouseMove={() => {

--- a/src/utils/countFamily.ts
+++ b/src/utils/countFamily.ts
@@ -5,8 +5,11 @@ import type { HierarchicalItem } from "../types";
  * 
  * The maximum number of levels is 10 to prevent the UI from getting too cluttered.
  */
-export function countFamily(a: HierarchicalItem, b: HierarchicalItem) {
+export function countFamily(a: HierarchicalItem, b: HierarchicalItem): number {
     for(let i = 0; i < 10; i++) {
-      if(a.hierarchy[`lvl${i}`] !== b.hierarchy[`lvl${i}`]) return i;
+      const ah = a.hierarchy[`lvl${i}`];
+      const bh = b.hierarchy[`lvl${i}`];
+      if(ah !== bh || !ah || !bh ) return i;
     }
+    throw new Error("This should never happen.");
 }

--- a/src/utils/getIcon.tsx
+++ b/src/utils/getIcon.tsx
@@ -1,13 +1,17 @@
 import { BiLogoPython, BiLogoJavascript, BiTerminal } from 'react-icons/bi';
+import { CgHashtag } from 'react-icons/cg';
 import { DocumentIcon } from './icons';
 
 import { HierarchicalItem } from '../types';
+import { isHeading } from './isHeading';
 
 /**
  * Returns the proper icon for the item based on the hierarchy.
  * @returns 
  */
 export function getIcon({ item }: { item: HierarchicalItem }) {
+    if(isHeading(item)) return CgHashtag;
+
     if(item?.hierarchy?.lvl0.toLowerCase().includes('python')) {
       return BiLogoPython;
     } else if (item?.hierarchy?.lvl0.toLowerCase().includes('javascript')) {

--- a/src/utils/isHeading.ts
+++ b/src/utils/isHeading.ts
@@ -1,0 +1,8 @@
+import { HierarchicalItem } from "../types";
+
+export function isHeading(item: HierarchicalItem): boolean {
+    for(let i = 2; i < Object.keys(item.hierarchy).length; i++) {
+        if(item.hierarchy[`lvl${i}`]) return true
+    }
+    return false;
+}


### PR DESCRIPTION
Adds different icon for fragment-level records and expands the breadcrumbs.

See the left pane (results list) in the before / after comparison:


| before | after |
|---|---|
| ![obrazek](https://github.com/apify/docs-search-modal/assets/61918049/ada4fcde-9b58-45c9-875b-7efe5e6ee70d) | ![obrazek](https://github.com/apify/docs-search-modal/assets/61918049/fd99a507-5d7b-4aab-9681-407d2fbfb0be) |


Improvement ideas welcome!

