### PR TITLE
fix: use `/platform` as the default top-ranking search prefix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docs-search-modal",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A custom implementation of the modal search for Apify Docs.",
   "author": "Jindřich Bär",
   "license": "ISC",

--- a/src/components/ApifySearch.tsx
+++ b/src/components/ApifySearch.tsx
@@ -121,7 +121,7 @@ function Autocomplete(props: any) {
                     let { location: { pathname } } = window;
     
                     if(['/', ''].includes(pathname)) {
-                      pathname = '/academy';
+                      pathname = '/platform';
                     }
     
                     const getLongestCommonPrefix = (a: string, b: string) => {


### PR DESCRIPTION
According to the results of the [Slack poll](https://apify.slack.com/archives/CQ96RHG2U/p1725010364319159), we should probably rank the `/platform` results higher than the ones from `/academy`.

The current implementation takes the current URL the user is on, and finds the result group with the longest common URL prefix. This group is then ranked first. This PR sets `/platform` (instead of `/academy`) as the default first group when searching from the homepage.