### PR TITLE
feat: render API paths as code snippets in breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ import { isHeading } from "../utils/isHeading";
  */
 export function Breadcrumbs({ item, highlight }: any) {
     const breadcrumbs = [
-      ...((!isHeading(item)) ? 
+      ...((!isHeading(item)) ?
         item?.breadcrumbs.map((x: any) => [null,{ value: x, matchLevel: 'full' }] ?? []) :
         item?.breadcrumbs.map((x: any) => [null,{ value: x, matchLevel: 'full' }] ?? []).slice(-1)
       ),
@@ -15,15 +15,27 @@ export function Breadcrumbs({ item, highlight }: any) {
         .sort(([a],[b]) => a.localeCompare(b))
         .slice(1)
     ].slice(1);
-  
+
     return (
       <div className='overflow-x-hidden overflow-ellipsis whitespace-nowrap leading-normal h-auto'>
-        { 
-          breadcrumbs.map(([_,b]: any, index) => ( (b?.value && b.value.length > 3) ?
-          (<span style={{color: 'slategray'}} className="breadcrumbs__item" key={index.toString()}>
-            {highlight({hit: { value: b.value ? decode(b.value) : '' }, attribute: 'value'})}
-          </span>) : null
-        )).filter(x => x)
+        {
+          breadcrumbs.map(([_,b]: any, index) => {
+          if (!b?.value || b.value.length < 2) {
+            return null;
+          }
+
+          return (<span style={{color: 'slategray'}} className="breadcrumbs__item" key={index.toString()}>
+            {
+              decode(b.value).startsWith('/v') ?
+              (<code className="bg-gray-100 dark:bg-slate-900 rounded-md px-1">
+                {highlight({hit: { value: b.value ? decode(b.value) : '' }, attribute: 'value'})}
+              </code>) :
+              (<span>
+                {highlight({hit: { value: b.value ? decode(b.value) : '' }, attribute: 'value'})}
+              </span>)
+            }
+          </span>)
+        }).filter(x => x)
         }
       </div>
     )


### PR DESCRIPTION
Together with the changes to the Algolia documentation crawler, this adds the API reference search to the search modal.

closes https://github.com/apify/apify-docs/issues/2154
closes https://github.com/apify/apify-docs/issues/2108