### PR TITLE
feat: update the dark palette

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ export function Breadcrumbs({ item, highlight }: any) {
           return (<span style={{color: 'slategray'}} className="breadcrumbs__item" key={index.toString()}>
             {
               decode(b.value).startsWith('/v') ?
-              (<code className="bg-gray-100 dark:bg-slate-900 rounded-md px-1">
+              (<code className="bg-gray-100 dark:bg-apify-background-subtle rounded-md px-1">
                 {highlight({hit: { value: b.value ? decode(b.value) : '' }, attribute: 'value'})}
               </code>) :
               (<span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,14 +3,14 @@ import { ArrowDownIcon, ArrowUpIcon, EnterIcon, EscapeIcon } from "../utils/icon
 function Tooltip() {
   return (
     <ul className="flex flex-row list-none space-x-3 mb-0 pl-0 mt-2">
-      <li className="space-x-2 text-slate-500 dark:text-slate-300 text-sm flex">
+      <li className="space-x-2 text-slate-500 dark:text-apify-text-muted text-sm flex">
         <kbd className="DocSearch-Button-Key">
           <EnterIcon />
         </kbd>
         <span className="DocSearch-Label">to select
       </span>
     </li>
-    <li className="space-x-2 text-slate-500 dark:text-slate-300 text-sm flex">
+    <li className="space-x-2 text-slate-500 dark:text-apify-text-muted text-sm flex">
       <span className="DocSearch-Button-Keys">
         <kbd className="DocSearch-Button-Key" >
           <ArrowUpIcon />
@@ -22,7 +22,7 @@ function Tooltip() {
       <span className="DocSearch-Label">to navigate
       </span>
     </li>
-    <li className="space-x-2 text-slate-500 dark:text-slate-300 text-sm flex">
+    <li className="space-x-2 text-slate-500 dark:text-apify-text-muted text-sm flex">
       <kbd className="DocSearch-Button-Key">
          <EscapeIcon />
       </kbd>
@@ -38,7 +38,7 @@ function Tooltip() {
   */
   export function Footer() {
     return (
-      <div className='hidden lg:block bg-white dark:bg-slate-900'>
+      <div className='hidden lg:block bg-white dark:bg-apify-background-muted'>
       <div className="flex flex-row justify-between h-16 w-full items-center px-5 shadow-inner">
         <Tooltip />
       </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -48,7 +48,7 @@ export function Modal({state, setActiveItemId, setContext, components, preview}:
                     uiTheme: document.querySelector('[data-theme="dark"]') ? 'DARK' : 'LIGHT',
                 }
             }
-            > <div className="flex flex-col h-full bg-white dark:bg-slate-800 relative">
+            > <div className="flex flex-col h-full bg-white dark:bg-apify-background relative">
         {state.collections[0].items.length === 0 ? (
         <div className="flex flex-col justify-center items-center flex-1">
             <div className='text-slate-400 font-medium text-lg px-3 py-1'>

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -38,7 +38,7 @@ function Toc( { items }: { items: TocItem[] } ) {
       { 
         items.map(( item, i ) => (
           <div style={{marginTop: '1em'}} key={i}>
-            <a href={item.href} className="text-slate-500 dark:text-slate-300">{i+1}. {item.title}</a>
+            <a href={item.href} className="text-slate-500 dark:text-apify-text-muted">{i+1}. {item.title}</a>
             { item.children && Toc({ items: item.children }) }
           </div>)
         )
@@ -51,25 +51,25 @@ export function PreviewPanel({ preview, components }: { preview: any, components
   const navigate = useNavigate();
 
   return (
-    <div className="h-full p-5 hidden lg:block bg-slate-50 dark:bg-slate-700 shadow-inner overflow-y-scroll">
+    <div className="h-full p-5 hidden lg:block bg-slate-50 dark:bg-apify-background-muted shadow-inner overflow-y-scroll">
       <Breadcrumbs key="breadcrumbs" item={preview} highlight={components.Highlight} />
       <div className="hover:cursor-pointer" onClick={() => navigate(preview.url)}>
-        <div key="title" className='w-full text-center text-slate-800 dark:text-slate-100 text-2xl p-7 font-semibold'>
+        <div key="title" className='w-full text-center text-slate-800 dark:text-apify-text text-2xl p-7 font-semibold'>
           <components.Highlight hit={preview} attribute={["name"]} />
         </div>
-        <div key="preview" className="px-6 pb-6 text-slate-600 dark:text-slate-200 border-none border-b-solid border-b-2 border-b-neutral-200  leading-6">
+        <div key="preview" className="px-6 pb-6 text-slate-600 dark:text-apify-text-muted border-none border-b-solid border-b-2 border-b-neutral-200  leading-6">
           {
             parseIntoBlocks(preview.content).map((block: any, i: number) => {
               if(block.type === 'text') {
                 return <p className='mb-3' key={i}>{
                   block.value.split('`').map((x: string, i: number) => {
                     if(i % 2 === 0) return <span key={i} className="inline">{x}</span>;
-                    return <code key={i} className='bg-slate-200 dark:bg-slate-600 px-1 py-0.5 mx-0.5 rounded inline'>{x}</code>
+                    return <code key={i} className='bg-slate-200 dark:bg-apify-background-subtle px-1 py-0.5 mx-0.5 rounded inline'>{x}</code>
                   })
                 }</p>
               } else {
                 return <div 
-                  className='mb-3 bg-slate-100 dark:bg-slate-800 rounded-l box-border' 
+                  className='mb-3 bg-slate-100 dark:bg-apify-background rounded-l box-border' 
                   key={i} 
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -88,7 +88,7 @@ export function PreviewPanel({ preview, components }: { preview: any, components
         (preview.toc?.length) && (preview.toc.length > 0) ?
         (
         <div className='px-6' key="toc">
-            <div className='text-slate-600 dark:text-slate-200 font-normal'>
+            <div className='text-slate-600 dark:text-apify-text-muted font-normal'>
               On this page:
             </div>
             <Toc items={preview.toc} />

--- a/src/components/ResultsItems.tsx
+++ b/src/components/ResultsItems.tsx
@@ -22,8 +22,8 @@ function ResultsItem({ item, components, className, onMouseMove, isActive }: { i
     return (
       <a 
         className={`
-          hover:cursor-pointer aa-ItemLink dark:text-white 
-          ${isActive ? 'dark:bg-slate-700 bg-slate-100 text-blue-400' : 'dark:bg-slate-800 bg-white'}  
+          hover:cursor-pointer aa-ItemLink dark:text-apify-text
+          ${isActive ? 'dark:bg-apify-background-subtle bg-slate-100 text-blue-400' : 'dark:bg-apify-background bg-white'}
         ${className}`} 
         style={{color: isActive ? 'rgb(96 165 250)' : undefined}}
         href={item.url} 
@@ -55,7 +55,7 @@ export function ResultsItems({ items, setActiveItemId, setContext, components, s
   return items?.map((item: any, i: number, a: any[]) => (
       <div key={item.objectID}>
         {((a?.[i-1]?.hierarchy as any)?.lvl0 !== (item?.hierarchy as any)?.lvl0 &&
-        <div key='heading' className='text-white bg-blue-400 dark:bg-sky-700 font-bold px-3 py-1' style={{fontSize: "13.6px", lineHeight: '18px'}}>
+        <div key='heading' className='text-white bg-blue-400 dark:bg-apify-primary-action font-bold px-3 py-1' style={{fontSize: "13.6px", lineHeight: '18px'}}>
           {(item?.hierarchy as any)?.lvl0}
         </div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -210,7 +210,7 @@ mark {
 }
 
 html[data-theme="dark"] mark {
-  color: #38bdf8 !important;
+  color: var(--color-primary-text, #38bdf8) !important;
 }
 
 .aa-Autocomplete {
@@ -219,7 +219,7 @@ html[data-theme="dark"] mark {
 
 html[data-theme="dark"] .aa-DetachedSearchButton {
   background: none !important;
-  border: 1px solid #7f8497 !important;
+  border: 1px solid var(--color-neutral-field-border, #7f8497) !important;
 }
 
 .aa-DetachedContainer--modal {
@@ -261,10 +261,10 @@ html[data-theme="dark"] .resultsItems a:hover {
 }
 
 html[data-theme="dark"] .aa-DetachedSearchButtonPlaceholder, html[data-theme="dark"] .aa-DetachedSearchButtonQuery, html[data-theme="dark"] .aa-SubmitIcon {
-  color: gainsboro !important;
+  color: var(--color-neutral-text-muted, gainsboro) !important;
 }
 html[data-theme="dark"] .aa-DetachedContainer {
-  background-color: #0d1a22 !important
+  background-color: var(--color-neutral-background, #0d1a22) !important
 }
 
 .aa-InputWrapper input {
@@ -279,12 +279,12 @@ html[data-theme="dark"] .aa-DetachedContainer {
 }
 
 html[data-theme="dark"] .aa-Form, html[data-theme="dark"] .aa-InputWrapper input {
-  background-color: #2e2f3a !important;
-  color: white !important;
+  background-color: var(--color-neutral-field-background, #2e2f3a) !important;
+  color: var(--color-neutral-text, white) !important;
 }
 
 html[data-theme="dark"] .aa-InputWrapper input ::placeholder, html[data-theme="dark"] .aa-DetachedCancelButton {
-  color: white !important;
+  color: var(--color-neutral-text-placeholder, white) !important;
 }
 
 .aa-DetachedCancelButton {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,17 @@ module.exports = {
         DEFAULT: '1px',
         '1': '1px',
       },
-      extend: {},
+      extend: {
+        colors: {
+          // Apify brand tokens, injected by @apify/docs-theme (fallbacks keep the old palette)
+          'apify-background': 'var(--color-neutral-background, #1e293b)',
+          'apify-background-muted': 'var(--color-neutral-background-muted, #334155)',
+          'apify-background-subtle': 'var(--color-neutral-background-subtle, #475569)',
+          'apify-text': 'var(--color-neutral-text, #f1f5f9)',
+          'apify-text-muted': 'var(--color-neutral-text-muted, #cbd5e1)',
+          'apify-primary-action': 'var(--color-primary-action, #0369a1)',
+        },
+      },
     },
     plugins: [],
   }


### PR DESCRIPTION
Dark mode colors were hardcoded (slate palette, one-off hexes), so the search modal clashed with the new dark theme rolled out in `apify-docs`. This maps them to the `--color-neutral-*` / `--color-primary-*` tokens injected by `@apify/docs-theme`, with the old colors kept as fallbacks for consumers without the theme. Light mode unchanged.

How `apify-docs` will look after the change:
<img width="1572" height="773" alt="image" src="https://github.com/user-attachments/assets/2249d0cd-e706-4434-9e57-d30aceca2d30" />

And how it looks now:
<img width="1562" height="851" alt="image" src="https://github.com/user-attachments/assets/72a9f1ef-89a4-4f1c-b9cb-1ad1aa6d053e" />
